### PR TITLE
Rerun uwuification with increased percentages if the text is unchanged

### DIFF
--- a/src/imsosorry/uwuification.py
+++ b/src/imsosorry/uwuification.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import random
 import re
-import string
 from functools import partial
 
 WORD_REPLACE = {
@@ -133,7 +132,15 @@ def tildify(text: str, strength: float) -> str:
     return REGEX_TILDE.sub(partial(tildes, strength=strength), text, 0)
 
 
-def _uwuify(text: str, *, stutter_strength: float, emoji_strength: float, tilde_strength: float) -> str:
+def uwuify(
+    text: str,
+    *,
+    stutter_strength: float = 0.2,
+    emoji_strength: float = 0.1,
+    tilde_strength: float = 0.1,
+) -> str:
+    """Take a string and returns an uwuified version of it."""
+
     original_text = text.lower()
     text = text.lower()
     text = word_replace(text)
@@ -143,32 +150,12 @@ def _uwuify(text: str, *, stutter_strength: float, emoji_strength: float, tilde_
     text = emoji(text, emoji_strength)
     text = tildify(text, tilde_strength)
 
-    if text == original_text:
-        text = _uwuify(
+    if text == original_text and any(char.isalpha() for char in text):
+        text = uwuify(
             text,
             stutter_strength=stutter_strength + 0.225,
             emoji_strength=emoji_strength + 0.075,
             tilde_strength=tilde_strength + 0.175,
         )
-
-    return text
-
-
-def uwuify(
-    text: str,
-    *,
-    stutter_strength: float = 0.2,
-    emoji_strength: float = 0.1,
-    tilde_strength: float = 0.1,
-) -> str:
-    """Take a string and returns an uwuified version of it."""
-    for letter in string.ascii_letters:
-        if letter in text:
-            return _uwuify(
-                text,
-                stutter_strength=stutter_strength,
-                emoji_strength=emoji_strength,
-                tilde_strength=tilde_strength,
-            )
 
     return text

--- a/src/imsosorry/uwuification.py
+++ b/src/imsosorry/uwuification.py
@@ -138,11 +138,12 @@ def uwuify(
     stutter_strength: float = 0.2,
     emoji_strength: float = 0.1,
     tilde_strength: float = 0.1,
+    max_emojifiable_len: int = 2,
 ) -> str:
     """Take a string and returns an uwuified version of it."""
     alpha = any(char.isalpha() for char in text)
 
-    if len(text) < 2 and not alpha:
+    if len(text) < max_emojifiable_len and not alpha:
         return random.choice(EMOJIS)
 
     original_text = text.lower()

--- a/src/imsosorry/uwuification.py
+++ b/src/imsosorry/uwuification.py
@@ -139,10 +139,23 @@ def uwuify(
     tilde_strength: float = 0.1,
 ) -> str:
     """Take a string and returns an uwuified version of it."""
+    original_text = text.lower()
+
+    # initial round
     text = text.lower()
     text = word_replace(text)
     text = nyaify(text)
     text = char_replace(text)
     text = stutter(text, stutter_strength)
     text = emoji(text, emoji_strength)
-    return tildify(text, tilde_strength)
+    text = tildify(text, tilde_strength)
+
+    while text == original_text:
+        text = uwuify(
+            text,
+            stutter_strength=stutter_strength + 0.225,
+            emoji_strength=emoji_strength + 0.075,
+            tilde_strength=tilde_strength + 0.175,
+        )
+
+    return text

--- a/src/imsosorry/uwuification.py
+++ b/src/imsosorry/uwuification.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import random
 import re
-from functools import partial
 import string
+from functools import partial
 
 WORD_REPLACE = {
     "small": "smol",
@@ -162,14 +162,13 @@ def uwuify(
     tilde_strength: float = 0.1,
 ) -> str:
     """Take a string and returns an uwuified version of it."""
-
     for letter in string.ascii_letters:
         if letter in text:
             return _uwuify(
                 text,
                 stutter_strength=stutter_strength,
                 emoji_strength=emoji_strength,
-                tilde_strength=tilde_strength
+                tilde_strength=tilde_strength,
             )
 
     return text

--- a/src/imsosorry/uwuification.py
+++ b/src/imsosorry/uwuification.py
@@ -150,7 +150,7 @@ def uwuify(
     text = emoji(text, emoji_strength)
     text = tildify(text, tilde_strength)
 
-    while text == original_text:
+    if text == original_text:
         text = uwuify(
             text,
             stutter_strength=stutter_strength + 0.225,

--- a/src/imsosorry/uwuification.py
+++ b/src/imsosorry/uwuification.py
@@ -140,7 +140,6 @@ def uwuify(
     tilde_strength: float = 0.1,
 ) -> str:
     """Take a string and returns an uwuified version of it."""
-
     original_text = text.lower()
     text = text.lower()
     text = word_replace(text)

--- a/src/imsosorry/uwuification.py
+++ b/src/imsosorry/uwuification.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import random
 import re
 from functools import partial
+import string
 
 WORD_REPLACE = {
     "small": "smol",
@@ -91,7 +92,8 @@ def stutter_replace(match: re.Match, strength: float = 0.0) -> str:
     """Replace a single character with a stuttered character."""
     match_string = match.group()
     if random.random() < strength:
-        return f"{match_string}-{match_string[-1]}"  # Stutter the last character
+        # Stutter the last character
+        return f"{match_string}-{match_string[-1]}"
     return match_string
 
 
@@ -131,17 +133,8 @@ def tildify(text: str, strength: float) -> str:
     return REGEX_TILDE.sub(partial(tildes, strength=strength), text, 0)
 
 
-def uwuify(
-    text: str,
-    *,
-    stutter_strength: float = 0.2,
-    emoji_strength: float = 0.1,
-    tilde_strength: float = 0.1,
-) -> str:
-    """Take a string and returns an uwuified version of it."""
+def _uwuify(text: str, *, stutter_strength: float, emoji_strength: float, tilde_strength: float) -> str:
     original_text = text.lower()
-
-    # initial round
     text = text.lower()
     text = word_replace(text)
     text = nyaify(text)
@@ -151,11 +144,32 @@ def uwuify(
     text = tildify(text, tilde_strength)
 
     if text == original_text:
-        text = uwuify(
+        text = _uwuify(
             text,
             stutter_strength=stutter_strength + 0.225,
             emoji_strength=emoji_strength + 0.075,
             tilde_strength=tilde_strength + 0.175,
         )
+
+    return text
+
+
+def uwuify(
+    text: str,
+    *,
+    stutter_strength: float = 0.2,
+    emoji_strength: float = 0.1,
+    tilde_strength: float = 0.1,
+) -> str:
+    """Take a string and returns an uwuified version of it."""
+
+    for letter in string.ascii_letters:
+        if letter in text:
+            return _uwuify(
+                text,
+                stutter_strength=stutter_strength,
+                emoji_strength=emoji_strength,
+                tilde_strength=tilde_strength
+            )
 
     return text

--- a/src/imsosorry/uwuification.py
+++ b/src/imsosorry/uwuification.py
@@ -140,6 +140,11 @@ def uwuify(
     tilde_strength: float = 0.1,
 ) -> str:
     """Take a string and returns an uwuified version of it."""
+    alpha = any(char.isalpha() for char in text)
+
+    if len(text) < 2 and not alpha:
+        return random.choice(EMOJIS)
+
     original_text = text.lower()
     text = text.lower()
     text = word_replace(text)
@@ -149,7 +154,7 @@ def uwuify(
     text = emoji(text, emoji_strength)
     text = tildify(text, tilde_strength)
 
-    if text == original_text and any(char.isalpha() for char in text):
+    if text == original_text and alpha:
         text = uwuify(
             text,
             stutter_strength=stutter_strength + 0.225,

--- a/tests/test_uwuification.py
+++ b/tests/test_uwuification.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from imsosorry.uwuification import EMOJIS, char_replace, emoji, nyaify, stutter, tildify, word_replace
+from imsosorry.uwuification import EMOJIS, char_replace, emoji, nyaify, stutter, tildify, uwuify, word_replace
 
 
 @pytest.mark.parametrize(
@@ -84,3 +84,16 @@ def test_emoji(strength: float, has_emoji: bool) -> None:  # noqa: FBT001 - yes
 def test_tildify(strength: float, in_text: str, out_text: str) -> None:
     """Test adding tildes."""
     assert tildify(in_text, strength) == out_text
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "-",
+        "^",
+        ")",
+    ],
+)
+def test_recursion(text: str) -> None:
+    """Check that recursion doesn't cause an infinite loop."""
+    assert uwuify(text) == text

--- a/tests/test_uwuification.py
+++ b/tests/test_uwuification.py
@@ -96,4 +96,4 @@ def test_tildify(strength: float, in_text: str, out_text: str) -> None:
 )
 def test_recursion(text: str) -> None:
     """Check that recursion doesn't cause an infinite loop."""
-    assert uwuify(text) == text
+    assert uwuify(text) in EMOJIS


### PR DESCRIPTION
The current uwuification function has a chance of some special text such as "it's just syntax" being unaffected by the uwuification. This change will rerun the uwuification function with increase chance parameters to ensure at least some uwuification for all texts.

Examples:
Before the uwuification change:
![image](https://github.com/letsbuilda/imsosorry/assets/91648368/df2d62b8-0a84-4065-832c-b8db4fe4ff00)
![image](https://github.com/letsbuilda/imsosorry/assets/91648368/afe24fd6-210e-4984-b077-e2635a5813e3)

After the uwuification change:
```py
>>> imsosorry.uwuify("It's just syntax")
"it's j-just syntax"
```

```py
>>> imsosorry.uwuify("sowwy")
'sowwy~'
```