### PR TITLE
Only run CI tests on Linux

### DIFF
--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -18,7 +18,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        os: [ ubuntu-latest, windows-latest, macos-latest ]
+        os: [ ubuntu-latest ]
         python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
 
     uses: darbiadev/.github/.github/workflows/python-test.yaml@4aa7c64159244d12bf9a39d42da89e80004d4af6 # v1.0.1


### PR DESCRIPTION
This is a pure Python library, so there's no need to run tests on multiple OSes.