### PR TITLE
Fix type hint

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -53,7 +53,7 @@ releases_github_path = REPO_LINK.removeprefix("https://github.com/")
 releases_release_uri = f"{REPO_LINK}/releases/tag/v%s"
 
 
-def linkcode_resolve(domain: str, info: dict) -> str:
+def linkcode_resolve(domain: str, info: dict) -> str | None:
     """linkcode_resolve."""
     if domain != "py":
         return None


### PR DESCRIPTION
```
(.venv) PS C:\Users\BradleyReynolds\dev\letsbuilda\imsosorry> pyright
c:\Users\BradleyReynolds\dev\letsbuilda\imsosorry\docs\source\conf.py
  c:\Users\BradleyReynolds\dev\letsbuilda\imsosorry\docs\source\conf.py:59:16 - error: Expression of type "None" cannot be assigned to return type "str"
    "None" is incompatible with "str" (reportReturnType)
  c:\Users\BradleyReynolds\dev\letsbuilda\imsosorry\docs\source\conf.py:61:16 - error: Expression of type "None" cannot be assigned to return type "str"
    "None" is incompatible with "str" (reportReturnType)
2 errors, 0 warnings, 0 informations
```