### PR TITLE
Update deprecated Ruff CLI args

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -52,7 +52,7 @@ function Invoke-Upgrade-Deps
 function Invoke-Lint
 {
     pre-commit run --all-files
-    python -m ruff --fix .
+    python -m ruff check --fix .
     python -m ruff format .
     python -m mypy --strict src/
 }


### PR DESCRIPTION
```
warning: `ruff <path>` is deprecated. Use `ruff check <path>` instead.
```