### PR TITLE
Test Copilot suggestion for linking codeblock

### DIFF
--- a/docs/source/history.rst
+++ b/docs/source/history.rst
@@ -1,7 +1,7 @@
 History
 =======
 
-Gitautas wanted a easy first Python project, so he made ``slowo_``.
+Gitautas wanted a easy first Python project, so he made `` `slowo <https://github.com/gitautas/slowo>`__ ``.
 I helped him with a bit of syntax and setting up the packaging boilerplate.
 
 He then raised an issue_ and a PR_ to replace the Sir Lancebot implemention with his new more featureful library.
@@ -12,6 +12,5 @@ But I wanted the code for my own bots, and it really is a kinda fun project to p
 
 In the future.... What comes next? An OwO command? Even more advanced UwUifications? Who knows?
 
-.. _slowo: https://github.com/gitautas/slowo
 .. _issue: https://github.com/python-discord/sir-lancebot/issues/812
 .. _PR: https://github.com/python-discord/sir-lancebot/pull/879


### PR DESCRIPTION
> In reStructuredText (reST), you can include a hyperlink within an inline code block by using the following syntax:
> 
> ```
> `` `link text <URL>`__ ``
> ```
> 
> Here's an example:
> 
> ```
> `` `GitHub <https://github.com>`__ ``
> ```
> 
> This will render as an inline code block with the text "GitHub" which is a hyperlink to https://github.com.