### PR TITLE
Stronger Uwuification for shorter strings

### DIFF
--- a/src/imsosorry/uwuification.py
+++ b/src/imsosorry/uwuification.py
@@ -132,15 +132,23 @@ def tildify(text: str, strength: float) -> str:
     return REGEX_TILDE.sub(partial(tildes, strength=strength), text, 0)
 
 
+# any text considered short, or less than this length, will have params bumped up
+LONG_TEXT = 50
+
+
 def uwuify(
     text: str,
     *,
     stutter_strength: float = 0.2,
     emoji_strength: float = 0.1,
-    tilde_strength: float = 0.1,
+    tilde_strength: float = 0.25,
     max_emojifiable_len: int = 2,
 ) -> str:
     """Take a string and returns an uwuified version of it."""
+    if len(text) < LONG_TEXT:
+        emoji_strength += 0.2
+        tilde_strength += 0.05
+
     alpha = any(char.isalpha() for char in text)
 
     if len(text) < max_emojifiable_len and not alpha:


### PR DESCRIPTION
Uwuification does not work well, especially for shorter strings of text, as too little effects like tildes and emojis are added (examples given below). This PR increases the amount of tildes, as well as bump certain amounts of parameters in the case of short strings to further optimize uwuification.

Examples:
Before:
```py
>>> import imsosorry
>>> imsosorry.uwuify("hello! how are you doing?")
'hewwo! how awe you doing?'
>>> imsosorry.uwuify("hello! how are you doing?")
'hewwo! h-how awe you d-doing?'
>>> imsosorry.uwuify("hello! how are you doing?")
'hewwo! how awe you d-doing?'
>>> imsosorry.uwuify("hello! how are you doing?")
'hewwo! h-how awe y-you doing?'
```

After:
```py
>>> import imsosorry
>>> imsosorry.uwuify("hello! how are you doing?")
'hewwo~ ^^;;  how a-awe you doing?'
>>> imsosorry.uwuify("hello! how are you doing?")
'hewwo! h-how a-awe~ you doing~ (✿oωo) '
>>> imsosorry.uwuify("hello! how are you doing?")
'hewwo! how awe you doing?'
>>> imsosorry.uwuify("hello! how are you doing?")
'hewwo~ 😳😳😳  how awe~ you~ d-doing?'
```

Notice a large difference in the quality of uwuified text before and after.