### PR TITLE
Release 1.2.3

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,6 +4,9 @@
 Changelog
 =========
 
+- :release:`1.2.3 <14th February 2025>`
+- :support:`-` Bump Trusted Publishing action
+
 - :release:`1.2.2 <14th February 2025>`
 - :support:`-` Setup Trusted Publishing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "imsosorry"
-version = "1.2.2"
+version = "1.2.3"
 description = "Sometimes it can be necessary to call upon the ancient arts..."
 authors = [
     { name = "Bradley Reynolds", email = "bradley.reynolds@darbia.dev" },


### PR DESCRIPTION
Just to bump Trusted Publishing action to get attestations enabled by default.