### PR TITLE
Make Sphinx require a Python version minimum of 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ tests = [
     "pytest-randomly==3.16.0",
 ]
 docs = [
-    "sphinx==8.1.3;python_version>'3.10'",
+    "sphinx==8.1.3;python_version>='3.10'",
     "furo==2024.8.6",
     "sphinx-autoapi==3.5.0",
     "releases==2.1.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ tests = [
     "pytest-randomly==3.16.0",
 ]
 docs = [
-    "sphinx==8.1.3",
+    "sphinx==8.1.3;python_version>'3.10'",
     "furo==2024.8.6",
     "sphinx-autoapi==3.5.0",
     "releases==2.1.1",


### PR DESCRIPTION
Sphinx is currently pinned to version 8.1.3 which is not supported by Python 3.9, which is the minimum Python version required by `project.requires_python`. This PR adds an environment marker forcing a minimum Python version of 3.10 to install Sphinx.