### PR TITLE
Switch from setuptools to beta uv-build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ docs = [
 ]
 
 [build-system]
-requires = ["setuptools>=61.0"]
-build-backend = "setuptools.build_meta"
+requires = ["uv_build"]
+build-backend = "uv_build"
 
 [tool.ruff]
 preview = true


### PR DESCRIPTION
This pull request includes changes to the `pyproject.toml` file to update the build system requirements.

Build system updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L36-R37): Changed the `requires` field from `setuptools>=61.0` to `uv_build` and updated the `build-backend` field from `setuptools.build_meta` to `uv_build`.