### PR TITLE
Switch build system from `setuptools` to beta `uv-build`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,8 @@ docs = [
 ]
 
 [build-system]
-requires = ["setuptools>=77.0.3"]
-build-backend = "setuptools.build_meta"
+requires = ["uv_build"]
+build-backend = "uv_build"
 
 [tool.ruff]
 preview = true


### PR DESCRIPTION
This pull request includes a small change to the `pyproject.toml` file. The change updates the build system requirements and backend to use `uv_build` instead of `setuptools`.

Changes to build system configuration:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L36-R37): Updated `requires` to `["uv_build"]` and `build-backend` to `"uv_build"`.